### PR TITLE
Allow any version of html-minifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you wish to use [minimize](https://github.com/Moveo/minimize), please use [ht
 Installation
 ---
 ```console
-npm install html-minifier-loader
+npm install html-minifier-loader html-minifier
 ```
 
 Example of webpack.config.js
@@ -17,7 +17,7 @@ The default is `{removeComments: true, collapseWhitespace: true}`.
 module: {
     loaders: [
         {    test: /\.html$/,
-             loader: 'raw!html-minifier'
+             loader: 'raw-loader!html-minifier-loader'
         }
     ]
 },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "homepage": "https://github.com/sapics/html-minifier-loader",
   "dependencies": {
-    "html-minifier": "^1.1.1",
     "loader-utils": "^0.2.12"
+  },
+  "peerDependencies": {
+    "html-minifier": "*"
   }
 }


### PR DESCRIPTION
As a workaround for https://github.com/kangax/html-minifier/issues/691, I'm using this loader to perform minification before passing the html to [html-loader](https://github.com/webpack/html-loader). This PR moves html-minifier to peerDependencies so I can use html-minifier@0.5.6, as well as simplifying the loader implementation itself.
