### PR TITLE
Add support for webpack >= 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(source) {
         removeComments: true,
         collapseWhitespace: true
       }
-    , options = this.options['html-minifier-loader'] || {}
+    , options = this.options && this.options['html-minifier-loader'] || {}
     , options2
   try {
     options2 = loaderUtils.getOptions(this)


### PR DESCRIPTION
> Webpack 3 already deprecated this.options in the loader context. webpack 4 removes it now.

[source](https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202)

I added check whether the `this.options` exsits.